### PR TITLE
Add vulkan-zig

### DIFF
--- a/packages/vulkan-zig.json
+++ b/packages/vulkan-zig.json
@@ -1,0 +1,10 @@
+{
+  "author": "Snektron",
+  "tags": [
+    "game",
+    "binding"
+  ],
+  "git": "https://github.com/Snektron/vulkan-zig",
+  "root_file": "generator/index.zig",
+  "description": "Build-time Vulkan binding generator for Zig"
+}

--- a/packages/vulkan-zig.json
+++ b/packages/vulkan-zig.json
@@ -5,6 +5,6 @@
     "binding"
   ],
   "git": "https://github.com/Snektron/vulkan-zig",
-  "root_file": "generator/index.zig",
+  "root_file": "/generator/index.zig",
   "description": "Build-time Vulkan binding generator for Zig"
 }


### PR DESCRIPTION
This PR adds my [Vulkan binding generator](https://github.com/Snektron/vulkan-zig). It is used as a build-time dependency, so i'm not sure whether it will be useful for now. Nevertheless, i (attempt to) keep it up-to-date with both latest Zig and the Vulkan XML registry.