### PR TITLE
Add support for null value for 'root_file'

### DIFF
--- a/tools/shared.zig
+++ b/tools/shared.zig
@@ -2,7 +2,7 @@ pub const PackageDescription = struct {
     author: []const u8,
     tags: [][]const u8,
     git: []const u8,
-    root_file: []const u8,
+    root_file: ?[]const u8,
     description: []const u8,
 };
 

--- a/tools/verifier.zig
+++ b/tools/verifier.zig
@@ -129,10 +129,12 @@ fn verifyPackageJson(
     if (pkg.description.len == 0)
         try errors.append("description is empty!");
 
-    if (pkg.root_file.len == 0) {
-        try errors.append("root_file is empty!");
-    } else if (!std.mem.startsWith(u8, pkg.root_file, "/")) {
-        try errors.append("root_file must start with a '/'!");
+    if (pkg.root_file) |root| {
+        if (root.len == 0) {
+            try errors.append("root_file is empty! Use 'null' if the root file is unrequired.");
+        } else if (!std.mem.startsWith(u8, root, "/")) {
+            try errors.append("root_file must start with a '/'!");
+        }
     }
 
     for (pkg.tags) |tag| {


### PR DESCRIPTION
Allows `root_file` to be `null` as some packages have a generated root file such as Zig-Vulkan and Zig-Wayland. As discussed here: https://github.com/ziglibs/repository/pull/17

This was also updated in zpm-server in: https://github.com/zigtools/zpm-server/commit/3192a82bd4274d343a8d0c9db8afb719286dc583