### PR TITLE
bearssl: main file location changed

### DIFF
--- a/packages/bearssl.json
+++ b/packages/bearssl.json
@@ -2,7 +2,7 @@
   "author": "xq",
   "description": "A BearSSL binding for Zig",
   "git": "https://github.com/MasterQ32/zig-bearssl",
-  "root_file": "/bearssl.zig",
+  "root_file": "/src/lib.zig",
   "tags": [
     "networking",
     "crypto",


### PR DESCRIPTION
as per https://github.com/MasterQ32/zig-bearssl/commit/05c4d9bb4d198aa1926e79a54f47868d0cf7687e