### PR TITLE
Fix: compilation errors of verifier.zig

### DIFF
--- a/tools/verifier.zig
+++ b/tools/verifier.zig
@@ -45,12 +45,14 @@ fn verifyFolder(directory_name: []const u8, verifier: VerifierFunction) !bool {
     const stderr_file = std.io.getStdErr();
     const stderr = stderr_file.writer();
 
-    var directory = try std.fs.cwd().openDir(directory_name, .{ .iterate = true, .no_follow = true });
+    var directory = try std.fs.cwd().openDir(directory_name, .{ .no_follow = true });
     defer directory.close();
+    var dirs = try std.fs.cwd().openIterableDir(directory_name, .{ .no_follow = true });
+    defer dirs.close();
 
     var success = true;
 
-    var iterator = directory.iterate();
+    var iterator = dirs.iterate();
     while (try iterator.next()) |entry| {
         if (entry.kind != .File)
             continue;


### PR DESCRIPTION
Fix 2 compilation errors of verifier.zig for ../zig-linux-x86_64-0.10.0-dev.3590+a12abc6d6.
(The following error log was reported in dev.3394, but is the same in dev.3590.)

1st:

$ ../zig-linux-x86_64-0.10.0-dev.3394+1a1b7a3af/zig build verify
> ./tools/verifier.zig:48:65: error: no member named 'iterate' in struct 'std.fs.Dir.OpenDirOptions'
>     var directory = try std.fs.cwd().openDir(directory_name, .{ .iterate = true, .no_follow = true });
>                                                                 ^
> error: verifier...
> error: The following command exited with error code 1:
> zig-linux-x86_64-0.10.0-dev.3394+1a1b7a3af/zig build-exe zigrepo/tools/verifier.zig --cache-dir zigrepo/zig-cache --global-cache-dir .cache/zig --name verifier --enable-cache
> error: the following build command failed with exit code 1:
> zigrepo/zig-cache/o/b2690b5f5dd78953d17c6a979ecfbe28/build zig-linux-x86_64-0.10.0-dev.3394+1a1b7a3af/zig zigrepo zigrepo/zig-cache .cache/zig verify

2nd:

$ ../zig-linux-x86_64-0.10.0-dev.3394+1a1b7a3af/zig build verify
> ./tools/verifier.zig:58:37: error: no member named 'openFile' in struct 'std.fs.IterableDir'
>             var file = try directory.openFile(entry.name, .{ .mode = .read_only });
>                                     ^
> error: verifier...
> error: The following command exited with error code 1:
> zig-linux-x86_64-0.10.0-dev.3394+1a1b7a3af/zig build-exe zigrepo/tools/verifier.zig --cache-dir zigrepo/zig-cache --global-cache-dir .cache/zig --name verifier --enable-cache
> error: the following build command failed with exit code 1:
> zigrepo/zig-cache/o/b2690b5f5dd78953d17c6a979ecfbe28/build zig-linux-x86_64-0.10.0-dev.3394+1a1b7a3af/zig zigrepo /h