### PR TITLE
rename repo to "coroutines" as this is more accurate about what the runtime does

### DIFF
--- a/packages/coroutinez.json
+++ b/packages/coroutinez.json
@@ -1,11 +1,11 @@
 {
   "author": "Florian Petautschnig (floscodes) <mail@floscodes.net>",
   "tags": [
-    "async"
+    "corountines"
   ],
-  "git": "https://github.com/floscodes/azync",
+  "git": "https://github.com/floscodes/coroutinez",
   "root_file": "/src/root.zig",
-  "description": "azync is a runtime for running asynchronous tasks in zig.",
+  "description": "coroutinez is a runtime for running tasks using coroutines in zig.",
   "license": "mit",
   "updated_at": "2025-06-08T17:25:58Z",
   "homepage": null


### PR DESCRIPTION
rename package
change repo url
change name in description